### PR TITLE
Add the ability to pass args to a query

### DIFF
--- a/lib/datomic/client.rb
+++ b/lib/datomic/client.rb
@@ -53,9 +53,13 @@ module Datomic
     end
 
     # Query can be a ruby data structure or a string representing clojure data
+    # If the args are not specified, the dbname sent in will be made into a
+    # db/alias and sent.
     def query(dbname, query, params = {})
       query = transmute_data(query)
-      args = [{:"db/alias" => [@storage, dbname].join('/')}].to_edn
+      args = params.delete(:args)
+      args ||= [{:"db/alias" => [@storage, dbname].join('/')}]
+      args = transmute_data(args)
       get root_url("api/query"), params.merge(:q => query, :args => args)
     end
 

--- a/lib/datomic/client.rb
+++ b/lib/datomic/client.rb
@@ -53,12 +53,15 @@ module Datomic
     end
 
     # Query can be a ruby data structure or a string representing clojure data
-    # If the args are not specified, the dbname sent in will be made into a
-    # db/alias and sent.
-    def query(dbname, query, params = {})
+    # If the args_or_dbname is a String, it will be converted into one arg
+    # pointing to that database.
+    def query(query, args_or_dbname, params = {})
+      args = if args_or_dbname.is_a?(String)
+               [{:"db/alias" => [@storage, args_or_dbname].join('/')}]
+             else
+               args_or_dbname
+             end
       query = transmute_data(query)
-      args = params.delete(:args)
-      args ||= [{:"db/alias" => [@storage, dbname].join('/')}]
       args = transmute_data(args)
       get root_url("api/query"), params.merge(:q => query, :args => args)
     end


### PR DESCRIPTION
Datomic queries can take multiple arguments, but currently we are only sending the db alias of the database we pass in. This is a first stab at making that more flexible. I wonder if we would be better served by changing the way the query function works altogether.
