### PR TITLE
Add convenience method to Datomic::Client for creating db/alias inputs

### DIFF
--- a/lib/datomic/client.rb
+++ b/lib/datomic/client.rb
@@ -57,9 +57,7 @@ module Datomic
     # pointing to that database.
     def query(query, args_or_dbname, params = {})
       query = transmute_data(query)
-      args = args_or_dbname.is_a?(String) ?
-        [{:"db/alias" => [@storage, args_or_dbname].join('/')}] :
-        args_or_dbname
+      args = args_or_dbname.is_a?(String) ? [self/args_or_dbname] : args_or_dbname
       args = transmute_data(args)
       get root_url("api/query"), params.merge(:q => query, :args => args)
     end
@@ -72,6 +70,10 @@ module Datomic
         :url => root_url('events', @storage, dbname),
         :headers => {:accept => "text/event-stream"},
         :block_response => block, &HANDLE_RESPONSE)
+    end
+
+    def /(dbname)
+      {:"db/alias" => "#@storage/#{dbname}"}
     end
 
     private

--- a/spec/datomic_client_spec.rb
+++ b/spec/datomic_client_spec.rb
@@ -194,4 +194,10 @@ describe Datomic::Client do
       resp.code.should == 503
     end
   end
+
+  describe "#/" do
+    it "returns an object that can be used as a database alias input to #query" do
+      (client/'test').should == {:"db/alias" => "#{storage}/test"}
+    end
+  end
 end


### PR DESCRIPTION
We can query with a single input like this:

``` ruby
datomic.query('...', dbname)
```

This is great. Unfortunately the same does not work for multiple inputs for which we have to specify the db/alias structure in full, like this:

``` ruby
datomic.query('...', [{:'db/alias' => "#{storage}/#{dbname}"}, input2])
```

This is not so great. Apart from all the extra typing, it also forces the caller to maintain additional state/knowledge (i.e. the storage value), and it's significantly different from calling with a single input. Ideally we would be able to do this:

``` ruby
datomic.query('...', [dbname, input2])
```

We cannot do this because we don't know which of the inputs will be database aliases. So we need some way to mark them explicitly.

This pull request adds the `/` method to Datomic::Client as a convenience shortcut for creating these db/alias inputs. Querying with multiple inputs can then look like this:

``` ruby
datomic.query('...', [datomic/dbname, input2])
```

This approach is backwards compatible, the db/alias input can still be specified in full. And it could potentially be extended in the future, e.g. to return an object that represented that specific database with additional behaviour.
